### PR TITLE
Add heatrejectionfanvariableflowcontrol algorithm updates

### DIFF
--- a/src/library.py
+++ b/src/library.py
@@ -789,6 +789,10 @@ class HeatRejectionFanVariableFlowControl(RuleCheckBase):
         self.df["normalized_m_ct_fan"] -= 1  # minus 1 to transform the data
         self.df["normalized_P_ct_fan"] -= 1
 
+        self.df = self.df.loc[
+            self.df["normalized_m_ct_fan"] > -0.5
+        ]  # filter out airflow points > -0.5, since the code requirement is at this point
+
         # linear regression
         reg = LinearRegression(fit_intercept=False).fit(
             self.df["normalized_m_ct_fan"].values.reshape(-1, 1),


### PR DESCRIPTION
This PR includes heat rejection fan variable flow control verification algorithm update, which excludes airflow's (normalized-1) greater than -0.5 to only reflect code requirement's data points. I appreciate it if you could review this PR.