### PR TITLE
Handle no. of data points flexibly

### DIFF
--- a/src/library.py
+++ b/src/library.py
@@ -833,30 +833,22 @@ class HeatRejectionFanVariableFlowControl(RuleCheckBase):
         pass
 
 
-class DemandControlVentilation(CheckLibBase):
-    points = [
-        "v_oa",
-        "s_ahu",
-        "s_eco",
-        "no_of_occ_per1",
-        "no_of_occ_per2",
-        "no_of_occ_per3",
-        "no_of_occ_per4",
-        "no_of_occ_core",
-    ]
-
+class DemandControlVentilation(RuleCheckBase):
     def verify(self):
         df_filtered = self.df.loc[
             (self.df["s_eco"] == 0.0) & (self.df["s_ahu"] != 0.0)
         ]  # filter out data when economizer isn't enabled
 
-        df_filtered["no_of_occ"] = (
-            df_filtered["no_of_occ_per1"]
-            + df_filtered["no_of_occ_per2"]
-            + df_filtered["no_of_occ_per3"]
-            + df_filtered["no_of_occ_per4"]
-            + df_filtered["no_of_occ_core"]
-        )
+        df_filtered["no_of_occ"] = 0.0
+        for var_name in self.points:
+            if var_name not in [
+                "v_oa",
+                "s_ahu",
+                "s_eco",
+                "tol",
+            ]:  # tol is added just in case it is used by other users
+                df_filtered["no_of_occ"] += df_filtered[var_name]
+
         # Pearson’s correlation
         corr, p_value = pearsonr(df_filtered["no_of_occ"], df_filtered["v_oa"])
 

--- a/src/run_verification_case.py
+++ b/src/run_verification_case.py
@@ -38,6 +38,9 @@ def run_verification_case(item_dict, run_path_postfix=""):
         if ("parameters" in item.item["datapoints_source"])
         else None
     )
+    cls.points = list(
+        (item.item["datapoints_source"]["idf_output_variables"]).keys()
+    ) + list((item.item["datapoints_source"]["parameters"]).keys())
     verification_obj = cls(df, parameters, f"{run_path}")
     md_content = verification_obj.add_md(None, "../results/imgs", "./imgs", item_dict)
     return {int(item_dict["no"]): md_content}

--- a/src/run_verification_case.py
+++ b/src/run_verification_case.py
@@ -38,10 +38,16 @@ def run_verification_case(item_dict, run_path_postfix=""):
         if ("parameters" in item.item["datapoints_source"])
         else None
     )
-    cls.points = list(
-        (item.item["datapoints_source"]["idf_output_variables"]).keys()
-    ) + list((item.item["datapoints_source"]["parameters"]).keys())
-    verification_obj = cls(df, parameters, f"{run_path}")
+
+    flexible_datapoint_item = False
+    for point_name in cls.points:
+        if (
+            "*" in point_name
+        ):  # * indicates it's a variable that can have a flexible number of data points
+            flexible_datapoint_item = True
+            break
+
+    verification_obj = cls(df, parameters, f"{run_path}", flexible_datapoint_item)
     md_content = verification_obj.add_md(None, "../results/imgs", "./imgs", item_dict)
     return {int(item_dict["no"]): md_content}
 


### PR DESCRIPTION
This PR includes the updates that can handle no. of data points flexibly.

For example, in the past, we hard-coded a total of 5 ```no_of_occ``` variables in the ```points``` class variable in ```DemandControlVentilation```. However, the no. of occ variables is different from each instance so, this PR solves this issue.

If this PR makes sense to you, I will apply the same logic to other verification items. Thank you!