### PR TITLE
Unit test for WLHP heat rejection controls

### DIFF
--- a/src/library/wlhp_loop_heat_rejection_controls.py
+++ b/src/library/wlhp_loop_heat_rejection_controls.py
@@ -5,13 +5,9 @@ class WLHPLoopHeatRejectionControl(RuleCheckBase):
     points = ["T_loop", "m_pump", "tol"]
 
     def verify(self):
-        self.df["T_max_loop"] = (
-            self.df.query("m_pump >0")["T_loop"]
-        ).max()
-        self.df["T_min_min"] = (
-            self.df.query("m_pump >0")["T_loop"]
-        ).min()
+        self.df["T_max_loop"] = (self.df.query("m_pump >0")["T_loop"]).max()
+        self.df["T_min_min"] = (self.df.query("m_pump >0")["T_loop"]).min()
 
-        self.result = (
-            self.df["T_max_loop"] - self.df["T_min_min"]
-        ) > 11.11 - self.df["tol"]
+        self.result = (self.df["T_max_loop"] - self.df["T_min_min"]) > 11.11 - self.df[
+            "tol"
+        ]

--- a/src/library/wlhp_loop_heat_rejection_controls.py
+++ b/src/library/wlhp_loop_heat_rejection_controls.py
@@ -2,16 +2,16 @@ from checklib import RuleCheckBase
 
 
 class WLHPLoopHeatRejectionControl(RuleCheckBase):
-    points = ["T_max_heating_loop", "T_min_cooling_loop", "m_pump", "tol"]
+    points = ["T_loop", "m_pump", "tol"]
 
     def verify(self):
-        self.df["T_max_heating_loop_max"] = (
-            self.df.query("m_pump >0")["T_max_heating_loop"]
+        self.df["T_max_loop"] = (
+            self.df.query("m_pump >0")["T_loop"]
         ).max()
-        self.df["T_min_cooling_loop_min"] = (
-            self.df.query("m_pump >0")["T_min_cooling_loop"]
+        self.df["T_min_min"] = (
+            self.df.query("m_pump >0")["T_loop"]
         ).min()
 
         self.result = (
-            self.df["T_max_heating_loop_max"] - self.df["T_min_cooling_loop_min"]
-        ) > 11.11 + self.df["tol"]
+            self.df["T_max_loop"] - self.df["T_min_min"]
+        ) > 11.11 - self.df["tol"]

--- a/tests/test_lib_wlhp_loop_heat_rejection_controls.py
+++ b/tests/test_lib_wlhp_loop_heat_rejection_controls.py
@@ -18,15 +18,14 @@ class TestWLHPLoopHeatRejectionControl(unittest.TestCase):
             [[25, 1, 1], [20, 1, 1]],
         ]
         results = []
+        df_agg = pd.DataFrame()
         for d in range(len(data)):
             df = pd.DataFrame(data[d], columns=points)
-
+            df_agg = pd.concat([df_agg, df])
             results.append(
-                bool(
-                    run_test_verification_with_data(
-                        "WLHPLoopHeatRejectionControl", df
-                    ).result.values[0]
-                )
+                run_test_verification_with_data(
+                    "WLHPLoopHeatRejectionControl", df
+                ).result.values[0]
             )
 
         expected_results = [
@@ -35,13 +34,13 @@ class TestWLHPLoopHeatRejectionControl(unittest.TestCase):
         ]
 
         # Perform verification
-        for i in range(len(data[d])):
-            self.assertTrue(results[i] is expected_results[i])
+        for i in range(len(results)):
+            self.assertTrue(bool(results[i]) is expected_results[i])
 
         # Print out results
-        df["results"] = results
-        df["expected_results"] = expected_results
-        df.to_csv(
+        df_agg["results"] = results
+        df_agg["expected_results"] = expected_results
+        df_agg.to_csv(
             "./tests/outputs/TestWLHPLoopHeatRejectionControl_test_wlhp_loop_heat_rejection_controls.csv"
         )
 

--- a/tests/test_lib_wlhp_loop_heat_rejection_controls.py
+++ b/tests/test_lib_wlhp_loop_heat_rejection_controls.py
@@ -1,0 +1,50 @@
+import unittest, sys
+
+sys.path.append("./src")
+from lib_unit_test_runner import *
+from library import *
+
+import json
+import pandas as pd
+import numpy as np
+
+
+class TestWLHPLoopHeatRejectionControl(unittest.TestCase):
+    def test_wlhp_loop_heat_rejection_controls(self):
+        points = ["T_loop", "m_pump", "tol"]
+
+        data = [
+            [[30, 1, 1], [10, 1, 1]],
+            [[25, 1, 1], [20, 1, 1]],
+        ]
+        results = []
+        for d in range(len(data)):
+            df = pd.DataFrame(data[d], columns=points)
+
+            results.append(
+                bool(
+                    run_test_verification_with_data(
+                        "WLHPLoopHeatRejectionControl", df
+                    ).result.values[0]
+                )
+            )
+
+        expected_results = [
+            True,
+            False,
+        ]
+
+        # Perform verification
+        for i in range(len(data[d])):
+            self.assertTrue(results[i] is expected_results[i])
+
+        # Print out results
+        df["results"] = results
+        df["expected_results"] = expected_results
+        df.to_csv(
+            "./tests/outputs/TestWLHPLoopHeatRejectionControl_test_wlhp_loop_heat_rejection_controls.csv"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lib_wlhp_loop_heat_rejection_controls.py
+++ b/tests/test_lib_wlhp_loop_heat_rejection_controls.py
@@ -18,10 +18,8 @@ class TestWLHPLoopHeatRejectionControl(unittest.TestCase):
             [[25, 1, 1], [20, 1, 1]],
         ]
         results = []
-        df_agg = pd.DataFrame()
         for d in range(len(data)):
             df = pd.DataFrame(data[d], columns=points)
-            df_agg = pd.concat([df_agg, df])
             results.append(
                 run_test_verification_with_data(
                     "WLHPLoopHeatRejectionControl", df
@@ -38,9 +36,9 @@ class TestWLHPLoopHeatRejectionControl(unittest.TestCase):
             self.assertTrue(bool(results[i]) is expected_results[i])
 
         # Print out results
-        df_agg["results"] = results
-        df_agg["expected_results"] = expected_results
-        df_agg.to_csv(
+        df["results"] = results
+        df["expected_results"] = expected_results
+        df.to_csv(
             "./tests/outputs/TestWLHPLoopHeatRejectionControl_test_wlhp_loop_heat_rejection_controls.csv"
         )
 


### PR DESCRIPTION
The proposed changes introduce a simplification to the water-loop heat pump loop heat rejection control verification and add a unit test for it.